### PR TITLE
github/workflows: No need to download the wasi-sysroot

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -31,13 +31,12 @@ jobs:
     steps:
       - name: Install tools/deps
         run: |
-          dnf -y install git wget clang llvm compiler-rt lld make bindgen-cli cargo rust rust-std-static-wasm32-unknown-unknown rust-std-static-wasm32-wasi
+          dnf -y install git wget clang llvm compiler-rt lld make wasi-libc-devel cargo rust rust-std-static-wasm32-unknown-unknown rust-std-static-wasm32-wasi
           wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | tar --strip-components=1 -xvzf - -C $(dirname $(rpm -ql compiler-rt | grep lib/libclang_rt.builtins-x86_64.a))
-          wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar -xvzf - -C ${RUNNER_TEMP}
 
       - uses: actions/checkout@v3
         with:
           fetch-depth: "0"
 
       - name: make
-        run: make WASI_SYSROOT=${RUNNER_TEMP}/wasi-sysroot V=1 E=1 all
+        run: make V=1 E=1 all

--- a/shared.mk
+++ b/shared.mk
@@ -10,6 +10,8 @@ else ifneq ("$(wildcard /usr/local/share/wasi-sysroot)", "")
         WASI_SYSROOT ?= /usr/local/share/wasi-sysroot
 endif
 
+export WASI_SYSROOT
+
 # By default compiler etc output is hidden, use
 #   make V=1 ...
 # to show it


### PR DESCRIPTION
The wasi-sysroot is now packaged by Fedora in the wasi-libc-devel & wasi-libc-static packages (just installing wasi-libc-devel should bring in the other if needed).

We also no longer need bindgen-cli as we are building the rust stuff from within the build.rs files.