### PR TITLE
libunit-wasm: Put LUW_SRB_FLAGS_ALL in the enum

### DIFF
--- a/API-C.md
+++ b/API-C.md
@@ -117,9 +117,10 @@ typedef enum {
         LUW_SRB_APPEND = 0x01,
         LUW_SRB_ALLOC = 0x02,
         LUW_SRB_FULL_SIZE = 0x04,
+
+        LUW_SRB_FLAGS_ALL = (LUW_SRB_NONE|LUW_SRB_APPEND|LUW_SRB_ALLOC|
+                             LUW_SRB_FULL_SIZE)
 } luw_srb_flags_t;
-#define LUW_SRB_FLAGS_ALL \
-        (LUW_SRB_NONE|LUW_SRB_APPEND|LUW_SRB_ALLOC|LUW_SRB_FULL_SIZE
 ```
 
 ## Structs

--- a/src/c/include/unit/unit-wasm.h
+++ b/src/c/include/unit/unit-wasm.h
@@ -126,9 +126,10 @@ typedef enum {
 	LUW_SRB_APPEND = 0x01,
 	LUW_SRB_ALLOC = 0x02,
 	LUW_SRB_FULL_SIZE = 0x04,
+
+	LUW_SRB_FLAGS_ALL = (LUW_SRB_NONE|LUW_SRB_APPEND|LUW_SRB_ALLOC|
+			     LUW_SRB_FULL_SIZE)
 } luw_srb_flags_t;
-#define LUW_SRB_FLAGS_ALL \
-	(LUW_SRB_NONE|LUW_SRB_APPEND|LUW_SRB_ALLOC|LUW_SRB_FULL_SIZE)
 
 typedef struct luw_hdr_field luw_http_hdr_iter_t;
 


### PR DESCRIPTION
No reason why this needed to be a separate #define.