### PR TITLE
libunit-wasm: Remove left over prototype from unit-wasm.h

### DIFF
--- a/src/c/include/unit/unit-wasm.h
+++ b/src/c/include/unit/unit-wasm.h
@@ -162,7 +162,6 @@ extern u32 luw_malloc_handler(size_t size);
 #pragma GCC visibility push(default)
 
 extern void luw_init_ctx(luw_ctx_t *ctx, u8 *addr, size_t offset);
-extern void luw_destroy_ctx(const luw_ctx_t *ctx);
 extern int luw_set_req_buf(luw_ctx_t *ctx, u8 **buf, unsigned long flags);
 extern const char *luw_get_http_path(const luw_ctx_t *ctx);
 extern const char *luw_get_http_method(const luw_ctx_t *ctx);


### PR DESCRIPTION
There was a luw_destroy_ctx() function at one point and its prototype was still in the header file...