### PR TITLE
Introduce nicer Rust wrappers for the libunit-wasm bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,11 @@ You can now use this in Unit with the following config
         "my-wasm-example": {
             "type": "wasm",
             "module": "/path/to/my-wasm-example/target/wasm32-wasi/debug/my_wasm_example.wasm",
-            "request_handler": "luw_request_handler",
+            "request_handler": "uwr_request_handler",
             "malloc_handler": "luw_malloc_handler",
             "free_handler": "luw_free_handler",
-            "module_init_handler": "luw_module_init_handler",
-            "module_end_handler": "luw_module_end_handler"
+            "module_init_handler": "uwr_module_init_handler",
+            "module_end_handler": "uwr_module_end_handler"
         }
     }
 }
@@ -304,20 +304,20 @@ Create the following Unit config
         "rust-echo-request": {
             "type": "wasm",
             "module": "/path/to/unit-wasm/examples/rust/echo-request/target/wasm32-wasi/debug/rust_echo_request.wasm",
-            "request_handler": "luw_request_handler",
+            "request_handler": "uwr_request_handler",
             "malloc_handler": "luw_malloc_handler",
             "free_handler": "luw_free_handler",
-            "module_init_handler": "luw_module_init_handler",
-            "module_end_handler": "luw_module_end_handler"
+            "module_init_handler": "uwr_module_init_handler",
+            "module_end_handler": "uwr_module_end_handler"
         },
         "rust-upload-reflector": {
             "type": "wasm",
             "module": "/path/to/unit-wasm/examples/rust/upload-reflector/rust_upload_reflector.wasm",
-            "request_handler": "luw_request_handler",
+            "request_handler": "uwr_request_handler",
             "malloc_handler": "luw_malloc_handler",
             "free_handler": "luw_free_handler",
-            "request_end_handler": "luw_request_end_handler",
-            "response_end_handler": "luw_response_end_handler"
+            "request_end_handler": "uwr_request_end_handler",
+            "response_end_handler": "uwr_response_end_handler"
         }
     }
 }

--- a/examples/rust/echo-request/src/lib.rs
+++ b/examples/rust/echo-request/src/lib.rs
@@ -6,30 +6,27 @@
  * Copyright (C) F5, Inc.
  */
 
-// Include RAW FFI Bindings.
-// @todo: Replace this with the new native Rust API
-use unit_wasm::ffi::*;
+use unit_wasm::rusty::*;
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
 use std::os::raw::c_void;
-use std::ptr;
+use std::ptr::null_mut;
 
 // Buffer of some size to store the copy of the request
-static mut REQUEST_BUF: *mut u8 = ptr::null_mut();
+static mut REQUEST_BUF: *mut u8 = null_mut();
 
 #[no_mangle]
-pub extern "C" fn luw_module_end_handler() {
+pub extern "C" fn uwr_module_end_handler() {
     unsafe {
-        luw_free(REQUEST_BUF as *mut c_void);
+        uwr_free(REQUEST_BUF);
     }
 }
 
 #[no_mangle]
-pub extern "C" fn luw_module_init_handler() {
+pub extern "C" fn uwr_module_init_handler() {
     unsafe {
-        REQUEST_BUF = luw_malloc(luw_mem_get_init_size().try_into().unwrap())
-            as *mut u8;
+        REQUEST_BUF = uwr_malloc(uwr_mem_get_init_size());
     }
 }
 
@@ -39,162 +36,90 @@ pub extern "C" fn hdr_iter_func(
     value: *const c_char,
     _data: *mut c_void,
 ) -> bool {
-    unsafe {
-        luw_mem_writep(
-            ctx,
-            "%s = %s\n\0".as_ptr() as *const c_char,
-            name,
-            value,
-        );
-    }
+    uwr_write_str!(ctx, "{} = {}\n", C2S!(name), C2S!(value));
 
     return true;
 }
 
 #[no_mangle]
-pub extern "C" fn luw_request_handler(addr: *mut u8) -> i32 {
-    // Need a initalization
+pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
+    // Declare a 0-initialised context structure
+    let ctx = &mut UWR_CTX_INITIALIZER();
+    // Initialise the context structure.
     //
-    // It sucks that rust needs this, this is supposed to be
-    // an opaque structure and the structure is 0-initialised
-    // in luw_init_ctx();
-    let mut ctx_: luw_ctx_t = luw_ctx_t {
-        addr: ptr::null_mut(),
-        mem: ptr::null_mut(),
-        req: ptr::null_mut(),
-        resp: ptr::null_mut(),
-        resp_hdr: ptr::null_mut(),
-        resp_offset: 0,
-        req_buf: ptr::null_mut(),
-        hdrp: ptr::null_mut(),
-        reqp: ptr::null_mut(),
-    };
-    let ctx: *mut luw_ctx_t = &mut ctx_;
+    // addr is the address of the previously allocated memory shared
+    // between the module and unit.
+    //
+    // The response data will be stored @ addr + offset (of 4096 bytes).
+    // This will leave some space for the response headers.
+    uwr_init_ctx(ctx, addr, 4096);
 
+    // Set where we will copy the request into
     unsafe {
-        // Initialise the context structure.
-        //
-        // addr is the address of the previously allocated memory shared
-        // between the module and unit.
-        //
-        // The response data will be stored @ addr + offset (of 4096 bytes).
-        // This will leave some space for the response headers.
-        luw_init_ctx(ctx, addr, 4096);
-
-        // Allocate memory to store the request and copy the request data.
-        luw_set_req_buf(ctx, &mut REQUEST_BUF, luw_srb_flags_t_LUW_SRB_NONE);
-
-        // Define the Response Body Text.
-
-        luw_mem_writep(
-            ctx,
-            " * Welcome to WebAssembly in Rust on Unit! \
-            [libunit-wasm (%d.%d.%d/%#0.8x)] \
-            *\n\n\0"
-                .as_ptr() as *const c_char,
-            LUW_VERSION_MAJOR,
-            LUW_VERSION_MINOR,
-            LUW_VERSION_PATCH,
-            LUW_VERSION_NUMBER,
-        );
-
-        luw_mem_writep(ctx, "[Request Info]\n\0".as_ptr() as *const c_char);
-
-        luw_mem_writep(
-            ctx,
-            "REQUEST_PATH = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_path(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "METHOD       = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_method(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "VERSION      = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_version(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "QUERY        = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_query(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "REMOTE       = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_remote(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "LOCAL_ADDR   = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_local_addr(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "LOCAL_PORT   = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_local_port(ctx) as *const c_char,
-        );
-        luw_mem_writep(
-            ctx,
-            "SERVER_NAME  = %s\n\0".as_ptr() as *const c_char,
-            luw_get_http_server_name(ctx) as *const c_char,
-        );
-
-        luw_mem_writep(
-            ctx,
-            "\n[Request Headers]\n\0".as_ptr() as *const c_char,
-        );
-
-        luw_http_hdr_iter(ctx, Some(hdr_iter_func), ptr::null_mut());
-
-        let method = CStr::from_ptr(luw_get_http_method(ctx)).to_str().unwrap();
-        if method == "POST" || method == "PUT" {
-            luw_mem_writep(
-                ctx,
-                "\n[%s data]\n\0".as_ptr() as *const c_char,
-                luw_get_http_method(ctx) as *const c_char,
-            );
-            luw_mem_writep_data(
-                ctx,
-                luw_get_http_content(ctx),
-                luw_get_http_content_len(ctx),
-            );
-            luw_mem_writep(ctx, "\n\0".as_ptr() as *const c_char);
-        }
-
-        let content_len = format!("{}\0", luw_get_response_data_size(ctx));
-
-        // Init Response Headers
-        //
-        // Needs the context, number of headers about to add as well as
-        // the offset where to store the headers. In this case we are
-        // storing the response headers at the beginning of our shared
-        // memory at offset 0.
-
-        luw_http_init_headers(ctx, 2, 0);
-        luw_http_add_header(
-            ctx,
-            0,
-            "Content-Type\0".as_ptr() as *const c_char,
-            "text/plain\0".as_ptr() as *const c_char,
-        );
-        luw_http_add_header(
-            ctx,
-            1,
-            "Content-Length\0".as_ptr() as *const c_char,
-            content_len.as_ptr() as *const c_char,
-        );
-
-        // This calls nxt_wasm_send_headers() in Unit
-        luw_http_send_headers(ctx);
-
-        // This calls nxt_wasm_send_response() in Unit
-        luw_http_send_response(ctx);
-
-        // This calls nxt_wasm_response_end() in Unit
-        luw_http_response_end();
+        uwr_set_req_buf(ctx, &mut REQUEST_BUF, LUW_SRB_NONE);
     }
+
+    // Define the Response Body Text.
+
+    uwr_write_str!(
+        ctx,
+        " * Welcome to WebAssembly in Rust on Unit! \
+            [libunit-wasm ({}.{}.{}/{:#010x})] *\n\n",
+        LUW_VERSION_MAJOR,
+        LUW_VERSION_MINOR,
+        LUW_VERSION_PATCH,
+        LUW_VERSION_NUMBER,
+    );
+
+    uwr_write_str!(ctx, "[Request Info]\n");
+
+    uwr_write_str!(ctx, "REQUEST_PATH = {}\n", uwr_get_http_path(ctx));
+    uwr_write_str!(ctx, "METHOD       = {}\n", uwr_get_http_method(ctx));
+    uwr_write_str!(ctx, "VERSION      = {}\n", uwr_get_http_version(ctx));
+    uwr_write_str!(ctx, "QUERY        = {}\n", uwr_get_http_query(ctx));
+    uwr_write_str!(ctx, "REMOTE       = {}\n", uwr_get_http_remote(ctx));
+    uwr_write_str!(ctx, "LOCAL_ADDR   = {}\n", uwr_get_http_local_addr(ctx));
+    uwr_write_str!(ctx, "LOCAL_PORT   = {}\n", uwr_get_http_local_port(ctx));
+    uwr_write_str!(ctx, "SERVER_NAME  = {}\n", uwr_get_http_server_name(ctx));
+
+    uwr_write_str!(ctx, "\n[Request Headers]\n");
+
+    uwr_http_hdr_iter(ctx, Some(hdr_iter_func), null_mut());
+
+    let method = uwr_get_http_method(ctx);
+    if method == "POST" || method == "PUT" {
+        uwr_write_str!(ctx, "\n[{} data]\n", method);
+        uwr_mem_write_buf(
+            ctx,
+            uwr_get_http_content(ctx),
+            uwr_get_http_content_len(ctx),
+        );
+        uwr_write_str!(ctx, "\n");
+    }
+
+    // Init Response Headers
+    //
+    // Needs the context, number of headers about to add as well as
+    // the offset where to store the headers. In this case we are
+    // storing the response headers at the beginning of our shared
+    // memory at offset 0.
+    uwr_http_init_headers(ctx, 2, 0);
+    uwr_http_add_header(ctx, 0, "Content-Type", "text/plain");
+    uwr_http_add_header(
+        ctx,
+        1,
+        "Content-Length",
+        &format!("{}", uwr_get_response_data_size(ctx)),
+    );
+
+    // This calls nxt_wasm_send_headers() in Unit
+    uwr_http_send_headers(ctx);
+
+    // This calls nxt_wasm_send_response() in Unit
+    uwr_http_send_response(ctx);
+
+    // This calls nxt_wasm_response_end() in Unit
+    uwr_http_response_end();
 
     return 0;
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -6,3 +6,4 @@
  */
 
 pub mod ffi;
+pub mod rusty;

--- a/src/rust/src/rusty/mod.rs
+++ b/src/rust/src/rusty/mod.rs
@@ -1,0 +1,3 @@
+// @todo: Check if this is valid?!
+extern crate unit_wasm_sys;
+pub use self::unit_wasm_sys::*;

--- a/src/rust/unit-wasm-sys/lib.rs
+++ b/src/rust/unit-wasm-sys/lib.rs
@@ -9,9 +9,11 @@
 mod bindings {
     #![allow(non_upper_case_globals)]
     #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
 
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
     include!("macros.rs");
+    include!("rusty.rs");
 }
 
 #[doc(no_inline)]

--- a/src/rust/unit-wasm-sys/lib.rs
+++ b/src/rust/unit-wasm-sys/lib.rs
@@ -9,7 +9,6 @@
 mod bindings {
     #![allow(non_upper_case_globals)]
     #![allow(non_camel_case_types)]
-    #![allow(dead_code)]
 
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
     include!("macros.rs");

--- a/src/rust/unit-wasm-sys/macros.rs
+++ b/src/rust/unit-wasm-sys/macros.rs
@@ -13,3 +13,8 @@ pub const LUW_VERSION_NUMBER: i32 =
     (LUW_VERSION_MAJOR << 24) |
     (LUW_VERSION_MINOR << 16) |
     (LUW_VERSION_PATCH << 8);
+
+pub const LUW_SRB_NONE:      u32 = luw_srb_flags_t_LUW_SRB_NONE;
+pub const LUW_SRB_APPEND:    u32 = luw_srb_flags_t_LUW_SRB_APPEND;
+pub const LUW_SRB_ALLOC:     u32 = luw_srb_flags_t_LUW_SRB_ALLOC;
+pub const LUW_SRB_FULL_SIZE: u32 = luw_srb_flags_t_LUW_SRB_FLAGS_ALL;

--- a/src/rust/unit-wasm-sys/rusty.rs
+++ b/src/rust/unit-wasm-sys/rusty.rs
@@ -1,0 +1,214 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) F5, Inc.
+ */
+
+use std::ffi::c_char;
+use std::ffi::c_void;
+use std::ffi::CStr;
+use std::ptr::null_mut;
+
+#[macro_export]
+macro_rules! C2S {
+    ($a:expr) => {{
+        unsafe { CStr::from_ptr($a).to_str().unwrap() }
+    }};
+}
+
+#[macro_export]
+macro_rules! S2C {
+    ($a:expr) => {{
+        format!("{}\0", $a)
+    }};
+}
+
+#[macro_export]
+macro_rules! uwr_write_str{
+    ($a:expr, $($arg:tt)*) => {
+    {
+        uwr_mem_write_str($a, &format!($($arg)*))
+    }
+}}
+
+pub const fn UWR_CTX_INITIALIZER() -> luw_ctx_t {
+    luw_ctx_t {
+        addr: null_mut(),
+        mem: null_mut(),
+        req: null_mut(),
+        resp: null_mut(),
+        resp_hdr: null_mut(),
+        resp_offset: 0,
+        req_buf: null_mut(),
+        hdrp: null_mut(),
+        reqp: null_mut(),
+    }
+}
+
+pub fn uwr_init_ctx(ctx: *mut luw_ctx_t, addr: *mut u8, offset: usize) {
+    unsafe {
+        luw_init_ctx(ctx, addr, offset);
+    }
+}
+
+pub fn uwr_set_req_buf(
+    ctx: *mut luw_ctx_t,
+    buf: *mut *mut u8,
+    flags: u32,
+) -> i32 {
+    unsafe { luw_set_req_buf(ctx, buf, flags) }
+}
+
+pub fn uwr_get_http_path(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_path(ctx))
+}
+
+pub fn uwr_get_http_method(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_method(ctx))
+}
+
+pub fn uwr_get_http_version(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_version(ctx))
+}
+
+pub fn uwr_get_http_query(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_query(ctx))
+}
+
+pub fn uwr_get_http_remote(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_remote(ctx))
+}
+
+pub fn uwr_get_http_local_addr(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_local_addr(ctx))
+}
+
+pub fn uwr_get_http_local_port(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_local_port(ctx))
+}
+
+pub fn uwr_get_http_server_name(ctx: *mut luw_ctx_t) -> &'static str {
+    C2S!(luw_get_http_server_name(ctx))
+}
+
+pub fn uwr_get_http_content(ctx: *const luw_ctx_t) -> *const u8 {
+    unsafe { luw_get_http_content(ctx) }
+}
+
+pub fn uwr_get_http_content_len(ctx: *const luw_ctx_t) -> usize {
+    unsafe { luw_get_http_content_len(ctx) }
+}
+
+pub fn uwr_get_http_content_sent(ctx: *const luw_ctx_t) -> usize {
+    unsafe { luw_get_http_content_sent(ctx) }
+}
+
+pub fn uwr_http_is_tls(ctx: *const luw_ctx_t) -> bool {
+    unsafe { luw_http_is_tls(ctx) }
+}
+
+pub fn uwr_http_hdr_iter(
+    ctx: *mut luw_ctx_t,
+    luw_http_hdr_iter_func: ::std::option::Option<
+        unsafe extern "C" fn(
+            ctx: *mut luw_ctx_t,
+            name: *const c_char,
+            value: *const c_char,
+            data: *mut c_void,
+        ) -> bool,
+    >,
+    user_data: *mut c_void,
+) {
+    unsafe { luw_http_hdr_iter(ctx, luw_http_hdr_iter_func, user_data) }
+}
+
+pub fn uwr_http_hdr_get_value(ctx: *mut luw_ctx_t, hdr: &str) -> &'static str {
+    C2S!(luw_http_hdr_get_value(ctx, S2C!(hdr).as_ptr() as *const i8))
+}
+
+pub fn uwr_get_response_data_size(ctx: *const luw_ctx_t) -> usize {
+    unsafe { luw_get_response_data_size(ctx) }
+}
+
+pub fn uwr_mem_write_str(ctx: *mut luw_ctx_t, src: &str) -> usize {
+    unsafe { luw_mem_writep_data(ctx, src.as_ptr(), src.len()) }
+}
+
+pub fn uwr_mem_write_buf(
+    ctx: *mut luw_ctx_t,
+    src: *const u8,
+    size: usize,
+) -> usize {
+    unsafe { luw_mem_writep_data(ctx, src, size) }
+}
+
+pub fn uwr_req_buf_append(ctx: *mut luw_ctx_t, src: *const u8) {
+    unsafe {
+        luw_req_buf_append(ctx, src);
+    }
+}
+
+pub fn uwr_mem_fill_buf_from_req(ctx: *mut luw_ctx_t, from: usize) -> usize {
+    unsafe { luw_mem_fill_buf_from_req(ctx, from) }
+}
+
+pub fn uwr_luw_mem_reset(ctx: *mut luw_ctx_t) {
+    unsafe {
+        luw_mem_reset(ctx);
+    }
+}
+
+pub fn uwr_http_send_response(ctx: *const luw_ctx_t) {
+    unsafe {
+        luw_http_send_response(ctx);
+    }
+}
+
+pub fn uwr_http_init_headers(ctx: *mut luw_ctx_t, nr: usize, offset: usize) {
+    unsafe {
+        luw_http_init_headers(ctx, nr, offset);
+    }
+}
+
+pub fn uwr_http_add_header(
+    ctx: *mut luw_ctx_t,
+    idx: u16,
+    name: &str,
+    value: &str,
+) {
+    unsafe {
+        luw_http_add_header(
+            ctx,
+            idx,
+            S2C!(name).as_ptr() as *const i8,
+            S2C!(value).as_ptr() as *const i8,
+        );
+    }
+}
+
+pub fn uwr_http_send_headers(ctx: *const luw_ctx_t) {
+    unsafe {
+        luw_http_send_headers(ctx);
+    }
+}
+
+pub fn uwr_http_response_end() {
+    unsafe {
+        luw_http_response_end();
+    }
+}
+
+pub fn uwr_mem_get_init_size() -> u32 {
+    unsafe { luw_mem_get_init_size() }
+}
+
+pub fn uwr_malloc(size: u32) -> *mut u8 {
+    unsafe { luw_malloc(size as usize) as *mut u8 }
+}
+
+pub fn uwr_free(ptr: *mut u8) {
+    unsafe {
+        luw_free(ptr as *mut c_void);
+    }
+}

--- a/unit-wasm-conf.json
+++ b/unit-wasm-conf.json
@@ -68,20 +68,20 @@
         "rust-echo-request": {
             "type": "wasm",
             "module": "/path/to/unit-wasm/examples/rust/echo-request/target/wasm32-wasi/debug/rust_echo_request.wasm",
-            "request_handler": "luw_request_handler",
+            "request_handler": "uwr_request_handler",
             "malloc_handler": "luw_malloc_handler",
             "free_handler": "luw_free_handler",
-            "module_init_handler": "luw_module_init_handler",
-            "module_end_handler": "luw_module_end_handler"
+            "module_init_handler": "uwr_module_init_handler",
+            "module_end_handler": "uwr_module_end_handler"
         },
         "rust-upload-reflector": {
             "type": "wasm",
             "module": "/path/to/unit-wasm/examples/rust/upload-reflector/rust_upload_reflector.wasm",
-            "request_handler": "luw_request_handler",
+            "request_handler": "uwr_request_handler",
             "malloc_handler": "luw_malloc_handler",
             "free_handler": "luw_free_handler",
-            "request_end_handler": "luw_request_end_handler",
-            "response_end_handler": "luw_response_end_handler"
+            "request_end_handler": "uwr_request_end_handler",
+            "response_end_handler": "uwr_response_end_handler"
         }
     }
 }


### PR DESCRIPTION
This patch set introduces nicer Rust wrappers (aka rusty) for the libunit-wasm bindings and switches the two demo applications over.

I have introduced them into a new namespace 'rusty', dunno if I did it correctly or not, but

```rust
use unit_wasm::rusty::*;                                                        
```

works.

Although these wrappers hide away most of the unsafe {} blocks, we do still need them when accessing static mutable variables, but I guess that's just a general rust thing.

These wrappers essentially cover the whole of libunit-wasm and not just what is currently used by the demos.

An ```API-Rust.md``` document still needs to be written, but I'm hoping a ```cp API-C.md API-Rust.md``` will make a good starting point...