### PR TITLE
Rust/unit-wasm-sys: Bump the version of the crate

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -12,4 +12,4 @@ path = "src/lib.rs"
 
 
 [dependencies]
-unit-wasm-sys = { path = "unit-wasm-sys", version = "0.1.1" }
+unit-wasm-sys = { path = "unit-wasm-sys", version = "0.1.2" }

--- a/src/rust/unit-wasm-sys/Cargo.toml
+++ b/src/rust/unit-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unit-wasm-sys"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Timo Stark <t.stark@nginx.com>", "Andrew Clayton <a.clayton@nginx.com>"]
 links = "unit-wasm"


### PR DESCRIPTION
unit-wasm-sys 0.1.2

Might as well do this now before the code changes and we bump the version again.

This version was published to crates.io