### PR TITLE
libunit-wasm: Remove the idx argument from luw_http_add_header()

### DIFF
--- a/API-C.md
+++ b/API-C.md
@@ -212,6 +212,9 @@ typedef struct {
 
         /* points to the end of ctx->req_buf */
         u8 *reqp;
+
+        /* tracks the response header index number */
+        s32 resp_hdr_idx;
 } luw_ctx_t;
 ```
 
@@ -864,13 +867,10 @@ luw_http_init_headers(ctx, 2, 0);
 ### luw_http_add_header
 
 ```C
-void luw_http_add_header(luw_ctx_t *ctx, u16 idx, const char *name,
-                         const char *value);
+void luw_http_add_header(luw_ctx_t *ctx, const char *name, const char *value);
 ```
 
 This function is used to add a header to the response.
-
-_idx_ is the index (starting at 0) of the header we are adding.
 
 _name_ is the name of the header.
 
@@ -882,8 +882,8 @@ Example
 char clen[32];
 /* ... */
 snprintf(clen, sizeof(clen), "%lu", luw_get_response_data_size(&ctx));
-luw_http_add_header(&ctx, 0, "Content-Type", "text/plain");
-luw_http_add_header(&ctx, 1, "Content-Length", clen);
+luw_http_add_header(&ctx, "Content-Type", "text/plain");
+luw_http_add_header(&ctx, "Content-Length", clen);
 ```
 
 ### luw_http_send_headers

--- a/examples/c/luw-echo-request.c
+++ b/examples/c/luw-echo-request.c
@@ -85,8 +85,8 @@ int luw_request_handler(u8 *addr)
 	luw_http_init_headers(&ctx, 2, 0);
 
 	snprintf(clen, sizeof(clen), "%lu", luw_get_response_data_size(&ctx));
-	luw_http_add_header(&ctx, 0, "Content-Type", "text/plain");
-	luw_http_add_header(&ctx, 1, "Content-Length", clen);
+	luw_http_add_header(&ctx, "Content-Type", "text/plain");
+	luw_http_add_header(&ctx, "Content-Length", clen);
 
 	luw_http_send_headers(&ctx);
 

--- a/examples/c/luw-upload-reflector.c
+++ b/examples/c/luw-upload-reflector.c
@@ -57,8 +57,8 @@ static int upload_reflector(luw_ctx_t *ctx)
 			 luw_get_http_content_len(ctx));
 
 		luw_http_init_headers(ctx, 2, 0);
-		luw_http_add_header(ctx, 0, "Content-Type", ct ? ct : defct);
-		luw_http_add_header(ctx, 1, "Content-Length", clen);
+		luw_http_add_header(ctx, "Content-Type", ct ? ct : defct);
+		luw_http_add_header(ctx, "Content-Length", clen);
 		luw_http_send_headers(ctx);
 	}
 

--- a/examples/rust/echo-request/src/lib.rs
+++ b/examples/rust/echo-request/src/lib.rs
@@ -104,10 +104,9 @@ pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
     // storing the response headers at the beginning of our shared
     // memory at offset 0.
     uwr_http_init_headers(ctx, 2, 0);
-    uwr_http_add_header(ctx, 0, "Content-Type", "text/plain");
+    uwr_http_add_header(ctx, "Content-Type", "text/plain");
     uwr_http_add_header(
         ctx,
-        1,
         "Content-Length",
         &format!("{}", uwr_get_response_data_size(ctx)),
     );

--- a/examples/rust/upload-reflector/src/lib.rs
+++ b/examples/rust/upload-reflector/src/lib.rs
@@ -49,10 +49,9 @@ pub fn upload_reflector(ctx: *mut luw_ctx_t) -> i32 {
         }
 
         uwr_http_init_headers(ctx, 2, 0);
-        uwr_http_add_header(ctx, 0, "Content-Type", ct);
+        uwr_http_add_header(ctx, "Content-Type", ct);
         uwr_http_add_header(
             ctx,
-            1,
             "Content-Length",
             &format!("{}", uwr_get_http_content_len(ctx)),
         );

--- a/src/c/include/unit/unit-wasm.h
+++ b/src/c/include/unit/unit-wasm.h
@@ -118,6 +118,9 @@ typedef struct {
 
 	/* points to the end of ctx->req_buf */
 	u8 *reqp;
+
+	/* tracks the response header index number */
+	s32 resp_hdr_idx;
 } luw_ctx_t;
 
 typedef enum {
@@ -189,7 +192,7 @@ extern size_t luw_mem_fill_buf_from_req(luw_ctx_t *ctx, size_t from);
 extern void luw_mem_reset(luw_ctx_t *ctx);
 extern void luw_http_send_response(const luw_ctx_t *ctx);
 extern void luw_http_init_headers(luw_ctx_t *ctx, size_t nr, size_t offset);
-extern void luw_http_add_header(luw_ctx_t *ctx, u16 idx, const char *name,
+extern void luw_http_add_header(luw_ctx_t *ctx, const char *name,
 				const char *value);
 extern void luw_http_send_headers(const luw_ctx_t *ctx);
 extern void luw_http_response_end(void);

--- a/src/rust/unit-wasm-sys/rusty.rs
+++ b/src/rust/unit-wasm-sys/rusty.rs
@@ -43,6 +43,7 @@ pub const fn UWR_CTX_INITIALIZER() -> luw_ctx_t {
         req_buf: null_mut(),
         hdrp: null_mut(),
         reqp: null_mut(),
+        resp_hdr_idx: -1,
     }
 }
 
@@ -173,14 +174,12 @@ pub fn uwr_http_init_headers(ctx: *mut luw_ctx_t, nr: usize, offset: usize) {
 
 pub fn uwr_http_add_header(
     ctx: *mut luw_ctx_t,
-    idx: u16,
     name: &str,
     value: &str,
 ) {
     unsafe {
         luw_http_add_header(
             ctx,
-            idx,
             S2C!(name).as_ptr() as *const i8,
             S2C!(value).as_ptr() as *const i8,
         );


### PR DESCRIPTION
This was used to specify the index of the response  header being added, starting at 0 and incrementing by one for each header.

Instead of having the programmer specify this, track it internally.

We add an extra check in luw_http_add_header() to make sure we aren't trying to add more headers than we said with luw_http_init_headers(), if we are, simply return.

This updates the API-C.md and the various examples and 'rusty' API wrapper.