### PR TITLE
Various Updates

### DIFF
--- a/API-Rust.md
+++ b/API-Rust.md
@@ -19,7 +19,23 @@ use std::os::raw::c_char;
 use std::os::raw::c_void;
 ```
 
+## Naming
+
+You will see references to functions etc starting with *luw_* or *LUW_* and
+*uwr_".
+
+**luw/LUW** (libunit-wasm) come from the underlying C library and in the Rust
+case are the auto-generated bindings with a few manual additions.
+
+**uwr** (Unit Wasm Rust aka '_rusty_') is a more Rust native wrapper ontop of
+the bindings.
+
+In _rusty_ the luw/LUW API is generally the low level stuff like the library
+version macros and the various function handlers where they can be used as is
+and there isn't a real need to create wrappers specifically for them.
+
 1. ['Rusty' Rust API](#rusty-rust-api)
+  * [Naming](#naming)
 2. [Macros](#macros)
   * [Version](#version)
   * [String Conversion](#string-conversion)

--- a/API-Rust.md
+++ b/API-Rust.md
@@ -64,6 +64,7 @@ and there isn't a real need to create wrappers specifically for them.
   * [uwr_get_http_local_port](#uwr_get_http_local_port)
   * [uwr_get_http_server_name](#uwr_get_http_server_name)
   * [uwr_get_http_content](#uwr_get_http_content)
+  * [uwr_get_http_content_str](#uwr_get_http_content_str)
   * [uwr_get_http_content_len](#uwr_get_http_content_len)
   * [uwr_get_http_content_sent](#uwr_get_http_content_sent)
   * [uwr_http_is_tls](#uwr_http_is_tls)
@@ -591,6 +592,14 @@ pub fn uwr_get_http_content(ctx: *const luw_ctx_t) -> *const u8;
 ```
 
 This function returns a pointer to the start of the request body.
+
+### uwr_get_http_content_str
+
+```Rsut
+pub fn uwr_get_http_content_str(ctx: *const luw_ctx_t) -> &'static str;
+```
+
+Same as above but returns a Rust str.
 
 ### uwr_get_http_content_len
 

--- a/src/rust/unit-wasm-sys/rusty.rs
+++ b/src/rust/unit-wasm-sys/rusty.rs
@@ -9,6 +9,8 @@ use std::ffi::c_char;
 use std::ffi::c_void;
 use std::ffi::CStr;
 use std::ptr::null_mut;
+use std::slice;
+use std::str;
 
 #[macro_export]
 macro_rules! C2S {
@@ -99,6 +101,16 @@ pub fn uwr_get_http_content(ctx: *const luw_ctx_t) -> *const u8 {
 
 pub fn uwr_get_http_content_len(ctx: *const luw_ctx_t) -> usize {
     unsafe { luw_get_http_content_len(ctx) }
+}
+
+pub fn uwr_get_http_content_str(ctx: *const luw_ctx_t) -> &'static str {
+    unsafe {
+        let slice = slice::from_raw_parts(
+            uwr_get_http_content(ctx),
+            uwr_get_http_content_len(ctx),
+        );
+        str::from_utf8(slice).unwrap()
+    }
 }
 
 pub fn uwr_get_http_content_sent(ctx: *const luw_ctx_t) -> usize {

--- a/src/rust/unit-wasm-sys/rusty.rs
+++ b/src/rust/unit-wasm-sys/rusty.rs
@@ -124,7 +124,10 @@ pub fn uwr_http_hdr_iter(
     unsafe { luw_http_hdr_iter(ctx, luw_http_hdr_iter_func, user_data) }
 }
 
-pub fn uwr_http_hdr_get_value(ctx: *const luw_ctx_t, hdr: &str) -> &'static str {
+pub fn uwr_http_hdr_get_value(
+    ctx: *const luw_ctx_t,
+    hdr: &str,
+) -> &'static str {
     C2S!(luw_http_hdr_get_value(ctx, S2C!(hdr).as_ptr() as *const i8))
 }
 
@@ -172,11 +175,7 @@ pub fn uwr_http_init_headers(ctx: *mut luw_ctx_t, nr: usize, offset: usize) {
     }
 }
 
-pub fn uwr_http_add_header(
-    ctx: *mut luw_ctx_t,
-    name: &str,
-    value: &str,
-) {
+pub fn uwr_http_add_header(ctx: *mut luw_ctx_t, name: &str, value: &str) {
     unsafe {
         luw_http_add_header(
             ctx,


### PR DESCRIPTION
- Run rusty.rs though rustfmt
- Add a note to API-Rust.md about the naming of things
- Add a uwr_get_http_content_str() to rusty that returns the body content as a Rust str.