### PR TITLE
Add a bare minimal rust example

### DIFF
--- a/API-Rust.md
+++ b/API-Rust.md
@@ -78,6 +78,8 @@ and there isn't a real need to create wrappers specifically for them.
   * [uwr_http_send_response](#uwr_http_send_response)
   * [uwr_http_init_headers](#uwr_http_init_headers)
   * [uwr_http_add_header](#uwr_http_add_header)
+  * [uwr_http_add_header_content_type](#uwr_http_add_header_content_type)
+  * [uwr_http_add_header_content_len](#uwr_http_add_header_content_len)
   * [uwr_http_send_headers](#uwr_http_send_headers)
   * [uwr_http_response_end](#uwr_http_response_end)
   * [uwr_mem_get_init_size](#uwr_mem_get_init_size)
@@ -858,6 +860,37 @@ uwr_http_add_header(
     &format!("{}", uwr_get_response_data_size(ctx)),
 );
 ```
+
+### uwr_http_add_header_content_type
+
+```Rust
+pub fn uwr_http_add_header_content_type(ctx: *mut luw_ctx_t, ctype: &str);
+```
+
+A convenience function for setting the 'Content-Type' response header.
+E.g the above example that adds the _Content-Type_ header could be
+written as
+
+```Rust
+uwr_http_add_header_content_type(ctx, "text/plain");
+```
+
+### uwr_http_add_header_content_len
+
+```Rust
+pub fn uwr_http_add_header_content_len(ctx: *mut luw_ctx_t);
+```
+
+A convenience function for setting the 'Content-Length' response header.
+E.g the above example that adds the _Content-Length_ header could be
+written as
+
+```Rust
+uwr_http_add_header_content_len(ctx);
+```
+
+This function uses [uwr_get_response_data_size](#uwr_get_response_data_size)
+internally to get the size of the response data.
 
 ### uwr_http_send_headers
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,14 @@ Create the following Unit config
             "action": {
                 "pass": "applications/rust-upload-reflector"
             }
+        },
+        {
+            "match": {
+                "uri": "/hello-world*"
+            },
+            "action": {
+                "pass": "applications/rust-hello-world"
+            }
         }
     ],
 
@@ -344,6 +352,13 @@ Create the following Unit config
             "free_handler": "luw_free_handler",
             "request_end_handler": "uwr_request_end_handler",
             "response_end_handler": "uwr_response_end_handler"
+        },
+        "rust-hello-world": {
+            "type": "wasm",
+            "module": "/path/to/unit-wasm/examples/rust/hello-world/target/wasm32-wasi/debug/rust_hello_world.wasm",
+            "request_handler": "uwr_request_handler",
+            "malloc_handler": "luw_malloc_handler",
+            "free_handler": "luw_free_handler"
         }
     }
 }

--- a/examples/rust/Makefile
+++ b/examples/rust/Makefile
@@ -2,7 +2,7 @@ include ../../shared.mk
 
 SDIR = examples/rust
 
-examples: rust-echo-request rust-upload-reflector
+examples: rust-echo-request rust-upload-reflector hello-world
 
 rust-echo-request: echo-request/Cargo.toml echo-request/src/lib.rs
 	$(PP_GEN) $(SDIR)/echo-request/target/wasm32-wasi/
@@ -12,6 +12,10 @@ rust-upload-reflector: upload-reflector/Cargo.toml upload-reflector/src/lib.rs
 	$(PP_GEN) $(SDIR)/upload-reflector/target/wasm32-wasi/
 	$(v)cd upload-reflector; cargo build --target=wasm32-wasi
 
+hello-world: hello-world/Cargo.toml hello-world/src/lib.rs
+	$(PP_GEN) $(SDIR)/hello-world/target/wasm32-wasi/
+	$(v)cd hello-world; cargo build --target=wasm32-wasi
+
 clean:
-	rm -f echo-request/Cargo.lock upload-reflector/Cargo.lock
-	rm -rf echo-request/target upload-reflector/target
+	rm -f */Cargo.lock
+	rm -rf */target

--- a/examples/rust/hello-world/Cargo.toml
+++ b/examples/rust/hello-world/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "rust-hello-world"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+unit-wasm = { path = "../../../src/rust", version = "0.1.2" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/rust/hello-world/src/lib.rs
+++ b/examples/rust/hello-world/src/lib.rs
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/*
+ * Copyright (C) Andrew Clayton
+ * Copyright (C) Timo Stark
+ * Copyright (C) F5, Inc.
+ */
+
+use unit_wasm::rusty::*;
+
+static mut REQUEST_BUF: *mut u8 = std::ptr::null_mut();
+
+#[no_mangle]
+pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
+    let ctx = &mut UWR_CTX_INITIALIZER();
+
+    uwr_init_ctx(ctx, addr, 4096);
+    uwr_set_req_buf(ctx, unsafe { &mut REQUEST_BUF }, LUW_SRB_ALLOC);
+
+    uwr_write_str!(
+        ctx,
+        " * Welcome to WebAssembly in Rust on Unit! \
+            [libunit-wasm ({}.{}.{}/{:#010x})] *\n\n",
+        LUW_VERSION_MAJOR,
+        LUW_VERSION_MINOR,
+        LUW_VERSION_PATCH,
+        LUW_VERSION_NUMBER,
+    );
+
+    uwr_http_init_headers(ctx, 2, 0);
+    uwr_http_add_header_content_type(ctx, "text/plain");
+    uwr_http_add_header_content_len(ctx);
+    uwr_http_send_headers(ctx);
+
+    uwr_http_send_response(ctx);
+    uwr_http_response_end();
+
+    uwr_free(unsafe { REQUEST_BUF });
+
+    return 0;
+}

--- a/src/rust/unit-wasm-sys/rusty.rs
+++ b/src/rust/unit-wasm-sys/rusty.rs
@@ -197,6 +197,18 @@ pub fn uwr_http_add_header(ctx: *mut luw_ctx_t, name: &str, value: &str) {
     }
 }
 
+pub fn uwr_http_add_header_content_type(ctx: *mut luw_ctx_t, ctype: &str) {
+    uwr_http_add_header(ctx, "Content-Type", ctype);
+}
+
+pub fn uwr_http_add_header_content_len(ctx: *mut luw_ctx_t) {
+    uwr_http_add_header(
+        ctx,
+        "Content-Length",
+        &format!("{}", uwr_get_response_data_size(ctx)),
+    );
+}
+
 pub fn uwr_http_send_headers(ctx: *const luw_ctx_t) {
     unsafe {
         luw_http_send_headers(ctx);

--- a/unit-wasm-conf.json
+++ b/unit-wasm-conf.json
@@ -43,6 +43,14 @@
             "action": {
                 "pass": "applications/rust-upload-reflector"
             }
+        },
+        {
+            "match": {
+                "uri": "/rust-hello-world*"
+            },
+            "action": {
+                "pass": "applications/rust-hello-world"
+            }
         }
     ],
 
@@ -82,6 +90,13 @@
             "free_handler": "luw_free_handler",
             "request_end_handler": "uwr_request_end_handler",
             "response_end_handler": "uwr_response_end_handler"
+        },
+        "rust-hello-world": {
+            "type": "wasm",
+            "module": "/path/to/unit-wasm/examples/rust/hello-world/target/wasm32-wasi/debug/rust_hello_world.wasm",
+            "request_handler": "uwr_request_handler",
+            "malloc_handler": "luw_malloc_handler",
+            "free_handler": "luw_free_handler"
         }
     }
 }


### PR DESCRIPTION
This adds a bare minimum rust example

It makes use of a couple of new convenience functions for adding the Content-Type and Content-Length headers.
