### PR TITLE
unit-wasm 0.2.0

### DIFF
--- a/API-C.md
+++ b/API-C.md
@@ -668,6 +668,8 @@ This function returns the total length of the content that was sent to the
 WebAssembly module so far. Remember, a single HTTP request may be split over
 several calls to luw_request_handler().
 
+_Version: 0.2.0_
+
 ### luw_http_is_tls
 
 ```C

--- a/API-Rust.md
+++ b/API-Rust.md
@@ -604,6 +604,8 @@ pub fn uwr_get_http_content_str(ctx: *const luw_ctx_t) -> &'static str;
 
 Same as above but returns a Rust str.
 
+_Version: 0.2.0_
+
 ### uwr_get_http_content_len
 
 ```Rust
@@ -632,6 +634,8 @@ pub fn uwr_get_http_total_content_sent(ctx: *const luw_ctx_t) -> usize;
 This function returns the total length of the content that was sent to the
 WebAssembly module so far. Remember, a single HTTP request may be split over
 several calls to luw_request_handler().
+
+_Version: 0.2.0_
 
 ### uwr_http_is_tls
 
@@ -886,6 +890,8 @@ written as
 uwr_http_add_header_content_type(ctx, "text/plain");
 ```
 
+_Version: 0.2.0_
+
 ### uwr_http_add_header_content_len
 
 ```Rust
@@ -902,6 +908,8 @@ uwr_http_add_header_content_len(ctx);
 
 This function uses [uwr_get_response_data_size](#uwr_get_response_data_size)
 internally to get the size of the response data.
+
+_Version: 0.2.0_
 
 ### uwr_http_send_headers
 

--- a/examples/rust/echo-request/Cargo.toml
+++ b/examples/rust/echo-request/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-unit-wasm = { path = "../../../src/rust", version = "0.1.2" }
+unit-wasm = { path = "../../../src/rust", version = "0.2.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/rust/hello-world/Cargo.toml
+++ b/examples/rust/hello-world/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-unit-wasm = { path = "../../../src/rust", version = "0.1.2" }
+unit-wasm = { path = "../../../src/rust", version = "0.2.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/examples/rust/upload-reflector/Cargo.toml
+++ b/examples/rust/upload-reflector/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-unit-wasm = { path = "../../../src/rust", version = "0.1.2" }
+unit-wasm = { path = "../../../src/rust", version = "0.2.0" }
 
 [lib]
 crate-type = ["cdylib"]

--- a/src/c/include/unit/unit-wasm.h
+++ b/src/c/include/unit/unit-wasm.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 #define LUW_VERSION_MAJOR	0
-#define LUW_VERSION_MINOR	1
+#define LUW_VERSION_MINOR	2
 #define LUW_VERSION_PATCH	0
 
 /* Version number in hex 0xMMmmpp00 */

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unit-wasm"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Timo Stark <t.stark@f5.com>", "Andrew Clayton <a.clayton@f5.com>"]
 description = "WASM SDK for NGINX Unit"
 license = "Apache-2.0"
@@ -12,4 +12,4 @@ path = "src/lib.rs"
 
 
 [dependencies]
-unit-wasm-sys = { path = "unit-wasm-sys", version = "0.1.4" }
+unit-wasm-sys = { path = "unit-wasm-sys", version = "0.2.0" }

--- a/src/rust/unit-wasm-sys/Cargo.toml
+++ b/src/rust/unit-wasm-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unit-wasm-sys"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 authors = ["Timo Stark <t.stark@nginx.com>", "Andrew Clayton <a.clayton@nginx.com>"]
 links = "unit-wasm"

--- a/src/rust/unit-wasm-sys/macros.rs
+++ b/src/rust/unit-wasm-sys/macros.rs
@@ -6,7 +6,7 @@
  */
 
 pub const LUW_VERSION_MAJOR: i32 = 0;
-pub const LUW_VERSION_MINOR: i32 = 1;
+pub const LUW_VERSION_MINOR: i32 = 2;
 pub const LUW_VERSION_PATCH: i32 = 0;
 
 pub const LUW_VERSION_NUMBER: i32 =


### PR DESCRIPTION
Sync everything to version 0.2.0

There's been numerous changes to libunit-wasm and the Rust bindings/rusty