### PR TITLE
rust: Change how bindgen creates enums

### DIFF
--- a/src/rust/unit-wasm-sys/build.rs
+++ b/src/rust/unit-wasm-sys/build.rs
@@ -36,6 +36,9 @@ fn generate_bindings() {
         .allowlist_function("^luw_.*")
         .allowlist_var("^luw_.*")
         .allowlist_type("^luw_.*")
+        .default_enum_style(bindgen::EnumVariation::Rust {
+            non_exhaustive: false,
+        })
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/rust/unit-wasm-sys/macros.rs
+++ b/src/rust/unit-wasm-sys/macros.rs
@@ -14,7 +14,7 @@ pub const LUW_VERSION_NUMBER: i32 =
     (LUW_VERSION_MINOR << 16) |
     (LUW_VERSION_PATCH << 8);
 
-pub const LUW_SRB_NONE:      u32 = luw_srb_flags_t_LUW_SRB_NONE;
-pub const LUW_SRB_APPEND:    u32 = luw_srb_flags_t_LUW_SRB_APPEND;
-pub const LUW_SRB_ALLOC:     u32 = luw_srb_flags_t_LUW_SRB_ALLOC;
-pub const LUW_SRB_FULL_SIZE: u32 = luw_srb_flags_t_LUW_SRB_FLAGS_ALL;
+pub const LUW_SRB_NONE:      u32 = luw_srb_flags_t::LUW_SRB_NONE as u32;
+pub const LUW_SRB_APPEND:    u32 = luw_srb_flags_t::LUW_SRB_APPEND as u32;
+pub const LUW_SRB_ALLOC:     u32 = luw_srb_flags_t::LUW_SRB_ALLOC as u32;
+pub const LUW_SRB_FULL_SIZE: u32 = luw_srb_flags_t::LUW_SRB_FLAGS_ALL as u32;


### PR DESCRIPTION
Previously bindgen was picking the 'constified_enum'. E.g it would turn the luw_srb_flags_t enum

  typedef enum {
          LUW_SRB_NONE = 0x00,
          LUW_SRB_APPEND = 0x01,
          LUW_SRB_ALLOC = 0x02,
          LUW_SRB_FULL_SIZE = 0x04,

          LUW_SRB_FLAGS_ALL = (LUW_SRB_NONE|LUW_SRB_APPEND|LUW_SRB_ALLOC|
                               LUW_SRB_FULL_SIZE)
  } luw_srb_flags_t;

into

  pub const luw_srb_flags_t_LUW_SRB_NONE: luw_srb_flags_t = 0;
  pub const luw_srb_flags_t_LUW_SRB_APPEND: luw_srb_flags_t = 1;
  pub const luw_srb_flags_t_LUW_SRB_ALLOC: luw_srb_flags_t = 2;
  pub const luw_srb_flags_t_LUW_SRB_FULL_SIZE: luw_srb_flags_t = 4;
  pub const luw_srb_flags_t_LUW_SRB_FLAGS_ALL: luw_srb_flags_t = 7;

But then this requires some further changes to make the names nicer without the type prefixed.

This will only be exasperated when adding an enum containing the HTTP status codes...

So instead, tell bindgen to use the 'rustified_enum' method which produces this

  pub enum luw_srb_flags_t {
      LUW_SRB_NONE = 0,
      LUW_SRB_APPEND = 1,
      LUW_SRB_ALLOC = 2,
      LUW_SRB_FULL_SIZE = 4,
      LUW_SRB_FLAGS_ALL = 7,
  }

which in theory requires no extra changes (it doesn't with the http status codes enum), however in this specific case, because these are actually bitflags we still need to cast them to u32 so they can be OR'd.