### PR TITLE
github/workflows: Add a Debian Testing builder

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -56,7 +56,7 @@ jobs:
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           . "$HOME/.cargo/env"
           rustup target add wasm32-wasi
-          wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar -xvzf - -C ${RUNNER_TEMP}
+          wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar -xzf - -C ${RUNNER_TEMP}
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -40,3 +40,29 @@ jobs:
 
       - name: make
         run: make V=1 E=1 all
+
+  debian-testing:
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:testing
+
+    steps:
+      - name: Install tools/deps
+        run: |
+          apt-get -y update
+          apt-get -y install git curl wget wasi-libc make clang llvm lld
+          wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | tar --strip-components=1 -xvzf - -C $(dirname $(clang -print-runtime-dir))
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          . "$HOME/.cargo/env"
+          rustup target add wasm32-wasi
+          wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar -xvzf - -C ${RUNNER_TEMP}
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: "0"
+
+      - name: make
+        run: |
+          . "$HOME/.cargo/env"
+          make WASI_SYSROOT=${RUNNER_TEMP}/wasi-sysroot V=1 E=1 all

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ that last task.
 Install the following as normal
 
 ```
-# apt install make clang llvm lld
+# apt install wasi-libc make clang llvm lld
 ```
 
 For the rest you will likely need to use [rustup](https://rustup.rs). Caveat


### PR DESCRIPTION
This requires some nefarious use of rustup and the funky rustup command line comes courtesy of <https://dentrassi.de/2020/06/17/headless-installation-of-cargo-and-rust/>