### PR TITLE
Add support for FreeBSD.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,14 @@ And finally similarly as Fedora (this requires a recentish clang)
 # wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | tar --strip-components=1 -xvzf - -C $(dirname $(clang -print-runtime-dir))
 ```
 
+### FreeBSD
+
+Install the following as normal
+
+```
+# pkg install gmake llvm13 rust wasi-compiler-rt13 wasi-libc
+```
+
 ## Quickstart in Developing Rust WebAssembly Modules for Unit
 
 1) Setup a suitable build environment as above.

--- a/shared.mk
+++ b/shared.mk
@@ -43,7 +43,7 @@ PP_AR		= @echo '  AR    '
 PP_CCLNK	= @echo '  CCLNK '
 PP_GEN		= @echo '  GEN   '
 
-CC       = clang
+CC      ?= clang
 CFLAGS  += -Wall -Wextra -Wdeclaration-after-statement -Wvla \
            -Wmissing-prototypes -Wstrict-prototypes -Wold-style-definition \
            -Wimplicit-function-declaration -Wimplicit-int -Wint-conversion \


### PR DESCRIPTION
With this patch it's possible to run `CC=clang13 gmake examples' and get wasm files.  However,
 ```
CC=clang13 gmake all
```
requires a bit more work.