### PR TITLE
rust: Fix building of unit-wasm

### DIFF
--- a/.github/workflows/build_tests.yaml
+++ b/.github/workflows/build_tests.yaml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Install tools/deps
         run: |
-          dnf -y install git wget clang llvm compiler-rt lld make wasi-libc-devel cargo rust rust-std-static-wasm32-unknown-unknown rust-std-static-wasm32-wasi
+          dnf -y install git wget clang llvm compiler-rt lld make wasi-libc-devel cargo rust rust-std-static-wasm32-wasip1
           wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | tar --strip-components=1 -xvzf - -C $(dirname $(clang -print-runtime-dir))
 
       - uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
           wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/libclang_rt.builtins-wasm32-wasi-20.0.tar.gz | tar --strip-components=1 -xvzf - -C $(dirname $(clang -print-runtime-dir))
           curl https://sh.rustup.rs -sSf | sh -s -- -y
           . "$HOME/.cargo/env"
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
           wget -O- https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/wasi-sysroot-20.0.tar.gz | tar -xzf - -C ${RUNNER_TEMP}
 
       - uses: actions/checkout@v3

--- a/examples/rust/Makefile
+++ b/examples/rust/Makefile
@@ -1,5 +1,8 @@
 include ../../shared.mk
 
+TARGET    = wasm32-wasip1
+CARGO_CMD = cargo build --target=$(TARGET)
+
 SDIR = examples/rust
 
 examples: rust-echo-request \
@@ -8,20 +11,20 @@ examples: rust-echo-request \
 	  rust-large-upload
 
 rust-echo-request: echo-request/Cargo.toml echo-request/src/lib.rs
-	$(PP_GEN) $(SDIR)/echo-request/target/wasm32-wasi/
-	$(v)cd echo-request; cargo build --target=wasm32-wasi
+	$(PP_GEN) $(SDIR)/echo-request/target/$(TARGET)/
+	$(v)cd echo-request; $(CARGO_CMD)
 
 rust-upload-reflector: upload-reflector/Cargo.toml upload-reflector/src/lib.rs
-	$(PP_GEN) $(SDIR)/upload-reflector/target/wasm32-wasi/
-	$(v)cd upload-reflector; cargo build --target=wasm32-wasi
+	$(PP_GEN) $(SDIR)/upload-reflector/target/$(TARGET)/
+	$(v)cd upload-reflector; $(CARGO_CMD)
 
 rust-hello-world: hello-world/Cargo.toml hello-world/src/lib.rs
-	$(PP_GEN) $(SDIR)/hello-world/target/wasm32-wasi/
-	$(v)cd hello-world; cargo build --target=wasm32-wasi
+	$(PP_GEN) $(SDIR)/hello-world/target/$(TARGET)/
+	$(v)cd hello-world; $(CARGO_CMD)
 
 rust-large-upload: large-upload/Cargo.toml large-upload/src/lib.rs
-	$(PP_GEN) $(SDIR)/large-upload/target/wasm32-wasi/
-	$(v)cd large-upload; cargo build --target=wasm32-wasi
+	$(PP_GEN) $(SDIR)/large-upload/target/$(TARGET)/
+	$(v)cd large-upload; $(CARGO_CMD)
 
 clean:
 	rm -f */Cargo.lock

--- a/src/rust/Makefile
+++ b/src/rust/Makefile
@@ -3,8 +3,8 @@ include ../../shared.mk
 SDIR = src/rust
 
 rustlib:
-	$(PP_GEN) $(SDIR)/target/wasm32-wasi
-	$(v)cargo build --target=wasm32-wasi
+	$(PP_GEN) $(SDIR)/target/wasm32-wasip1
+	$(v)cargo build --target=wasm32-wasip1
 
 clean:
 	rm -f Cargo.lock unit-wasm-sys/Cargo.lock

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -9,7 +9,7 @@ cargo add unit-wasm
 
 ## Prerequisites
 
-- target add wasm32-wasi. `rustup target add wasm32-wasi`
+- target add wasm32-wasip1. `rustup target add wasm32-wasip1`
 
 ## From Source
 


### PR DESCRIPTION
    rust: Fix building of unit-wasm
    
    When building the unit-wasm crate we were getting the following
    compiler error
    
      error: failed to run `rustc` to learn about target-specific information
    
      ...
    
        --- stderr
        error: Error loading target specification: Could not find specification for target "wasm32-wasi". Run `rustc --print target-list` for a list of built-in targets
    
    This is due to wasm32-wasi being renamed to wasm32-wasip1, with
    wasm32-wasi being kept clear for an eventual WASI 1.0 release.
    
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>