### PR TITLE
examples/rust: Remove some redundant unsafe blocks

### DIFF
--- a/examples/rust/echo-request/src/lib.rs
+++ b/examples/rust/echo-request/src/lib.rs
@@ -51,7 +51,7 @@ pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
     uwr_init_ctx(ctx, addr, 4096);
 
     // Set where we will copy the request into
-    uwr_set_req_buf(ctx, unsafe { addr_of_mut!(REQUEST_BUF) }, LUW_SRB_NONE);
+    uwr_set_req_buf(ctx, addr_of_mut!(REQUEST_BUF), LUW_SRB_NONE);
 
     // Define the Response Body Text.
 

--- a/examples/rust/large-upload/src/lib.rs
+++ b/examples/rust/large-upload/src/lib.rs
@@ -32,7 +32,7 @@ pub unsafe extern "C" fn uwr_response_end_handler() {
 
 #[no_mangle]
 pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
-    let ctx: *mut luw_ctx_t = unsafe { addr_of_mut!(CTX) };
+    let ctx: *mut luw_ctx_t = addr_of_mut!(CTX);
     let mut f;
     let bytes_wrote: isize;
     let mut total = unsafe { TOTAL_BYTES_WROTE };
@@ -41,7 +41,7 @@ pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
         uwr_init_ctx(ctx, addr, 0);
         uwr_set_req_buf(
             ctx,
-            unsafe { addr_of_mut!(REQUEST_BUF) },
+            addr_of_mut!(REQUEST_BUF),
             LUW_SRB_NONE,
         );
 

--- a/examples/rust/upload-reflector/src/lib.rs
+++ b/examples/rust/upload-reflector/src/lib.rs
@@ -72,7 +72,7 @@ pub fn upload_reflector(ctx: *mut luw_ctx_t) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
-    let ctx: *mut luw_ctx_t = unsafe { addr_of_mut!(CTX) };
+    let ctx: *mut luw_ctx_t = addr_of_mut!(CTX);
 
     if unsafe { REQUEST_BUF.is_null() } {
         uwr_init_ctx(ctx, addr, 0 /* Response offset */);
@@ -87,7 +87,7 @@ pub extern "C" fn uwr_request_handler(addr: *mut u8) -> i32 {
          */
         uwr_set_req_buf(
             ctx,
-            unsafe { addr_of_mut!(REQUEST_BUF) },
+            addr_of_mut!(REQUEST_BUF),
             LUW_SRB_APPEND | LUW_SRB_ALLOC | LUW_SRB_FULL_SIZE,
         );
     } else {


### PR DESCRIPTION
    examples/rust: Remove some redundant unsafe blocks
    
    ... as noted by the compiler...
    
    Fixes: 2cf492f ("examples/rust: Fix some new rustc warnings")
    Signed-off-by: Andrew Clayton <a.clayton@nginx.com>